### PR TITLE
Entity API (including force movement

### DIFF
--- a/repository/scripts/admin/commands/test.js
+++ b/repository/scripts/admin/commands/test.js
@@ -21,8 +21,10 @@
  */
 /* globals EventType, ENGINE */
 var coords = require('map/coords');
+var _entity = require('engine/entity');
 
 var util = require('util');
+var anim = require('anim');
 var dialog = require('dialog');
 var chat = require('chat');
 var map = require('map');
@@ -44,7 +46,7 @@ module.exports = (function () {
 			var args = ctx.cmdArgs;
 			var player = ctx.player;
 			if (args.length < 1) {
-				util.sendCommandResponse(player, "Usage: test <type>", ctx.console);
+				chat.sendCommandResponse(player, "Usage: test <type>", ctx.console);
 			}
 			
 			switch (args[0]) {
@@ -60,6 +62,9 @@ module.exports = (function () {
 			case "mestype":
 				testMessageType(player, args, ctx);
 				return;
+			case "move":
+				testDelayedMovement(player, args, ctx);
+				return;
 			}
 		});
 		
@@ -70,7 +75,7 @@ module.exports = (function () {
 			player.getHeadIcons().setIcon(parseInt(args[3]), parseInt(args[1]), parseInt(args[2]));
 			player.getHeadIcons().refresh();
 		} else {
-			util.sendCommandResponse(player, "Usage: test icons <main_sprite> <sub_sprite> <slot>", ctx.console);
+			chat.sendCommandResponse(player, "Usage: test icons <main_sprite> <sub_sprite> <slot>", ctx.console);
 		}
 	}
 	
@@ -91,7 +96,7 @@ module.exports = (function () {
 	
 	function testLocAnim(player, args, ctx) {
 		if (args.length < 2 || isNaN(args[1])) {
-			util.sendCommandResponse(player, "Usage: test locanim <anim_id>", ctx.console);
+			chat.sendCommandResponse(player, "Usage: test locanim <anim_id>", ctx.console);
 			return;
 		}
 		var animId = parseInt(args[1]);
@@ -104,11 +109,20 @@ module.exports = (function () {
 	
 	function testMessageType(player, args, ctx) {
 		if (args.length < 2 || isNaN(args[1])) {
-			util.sendCommandResponse(player, "Usage: test mestype <channel_id>", ctx.console);
+			chat.sendCommandResponse(player, "Usage: test mestype <channel_id>", ctx.console);
 			return;
 		}
 		var mesType = args[1];
 		chat.sendMessage(player, "Test", mesType);
+	}
+	
+	function testDelayedMovement(player, args, ctx) {
+		testLocAnim(player, ["locanim", 497], ctx);
+		anim.run(player, 751);
+		var currentCoords = map.getCoords(player);
+		var targetCoords = coords(currentCoords, 0, -5, 0);
+		chat.sendCommandResponse(player, "Running foce move to: "+targetCoords, ctx.console);
+		_entity.forceMove(player, targetCoords, 105);
 	}
 })();
 

--- a/repository/scripts/node_modules/engine/entity.js
+++ b/repository/scripts/node_modules/engine/entity.js
@@ -1,0 +1,40 @@
+/**
+ * 
+ */
+/* globals ENTITY_ENGINE */
+
+module.exports = (function () {
+	return {
+		moveTo : moveTo,
+		setCoords : setCoords,
+		getCoords : getCoords,
+		say : say,
+		getName : getName,
+		forceMove : forceMove
+	};
+	
+	function moveTo (entity, coords) {
+		ENTITY_ENGINE.moveTo(entity, coords);
+	}
+	
+	function setCoords (entity, coords) {
+		ENTITY_ENGINE.setCoords(entity, coords);
+	}
+	
+	function getCoords (entity) {
+		return ENTITY_ENGINE.getCoords(entity);
+	}
+	
+	function say (entity, message) {
+		ENTITY_ENGINE.say(entity, message);
+	}
+	
+	function getName (entity) {
+		return ENTITY_ENGINE.getName(entity);
+	}
+	
+	function forceMove (entity, coords, length) {
+		ENTITY_ENGINE.forceMove(entity, coords, length);
+	}
+	
+})();

--- a/src/main/java/org/virtue/Virtue.java
+++ b/src/main/java/org/virtue/Virtue.java
@@ -47,6 +47,7 @@ import org.virtue.engine.cycle.ticks.SystemUpdateTick;
 import org.virtue.engine.script.JSListeners;
 import org.virtue.engine.script.api.impl.VirtueClanAPI;
 import org.virtue.engine.script.api.impl.VirtueConfigAPI;
+import org.virtue.engine.script.api.impl.VirtueEntityAPI;
 import org.virtue.engine.script.api.impl.VirtueMapAPI;
 import org.virtue.engine.script.api.impl.VirtueQuestAPI;
 import org.virtue.engine.script.api.impl.VirtueScriptAPI;
@@ -309,6 +310,7 @@ public class Virtue {
 		scripts.setMapApi(new VirtueMapAPI());
 		scripts.setConfigApi(new VirtueConfigAPI(configProvider));
 		scripts.setQuestApi(new VirtueQuestAPI(configProvider));
+		scripts.setEntityApi(new VirtueEntityAPI());
 		scripts.load();
 	}
 	

--- a/src/main/java/org/virtue/engine/script/JSListeners.java
+++ b/src/main/java/org/virtue/engine/script/JSListeners.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.virtue.engine.script.api.ClanAPI;
 import org.virtue.engine.script.api.ConfigAPI;
+import org.virtue.engine.script.api.EntityAPI;
 import org.virtue.engine.script.api.MapAPI;
 import org.virtue.engine.script.api.QuestAPI;
 import org.virtue.engine.script.api.ScriptAPI;
@@ -136,6 +137,8 @@ public class JSListeners implements ScriptManager {
 	
 	private QuestAPI questApi;
 	
+	private EntityAPI entityApi;
+	
 	private ScriptEngine engine;
 	
 	private File scriptDir;
@@ -160,6 +163,7 @@ public class JSListeners implements ScriptManager {
 		engine.put("MAP_ENGINE", mapApi);
 		engine.put("configApi", configApi);
 		engine.put("QUEST_ENGINE", questApi);
+		engine.put("ENTITY_ENGINE", entityApi);
 		engine.put("scriptEngine", this);
 		
 		Map<String, Integer> map = new HashMap<>();
@@ -370,6 +374,14 @@ public class JSListeners implements ScriptManager {
 
 	public void setQuestApi(QuestAPI questApi) {
 		this.questApi = questApi;
+	}
+
+	public EntityAPI getEntityApi() {
+		return entityApi;
+	}
+
+	public void setEntityApi(EntityAPI entityApi) {
+		this.entityApi = entityApi;
 	}
 
 	/**

--- a/src/main/java/org/virtue/engine/script/api/EntityAPI.java
+++ b/src/main/java/org/virtue/engine/script/api/EntityAPI.java
@@ -1,0 +1,55 @@
+package org.virtue.engine.script.api;
+
+import org.virtue.game.entity.Entity;
+import org.virtue.game.map.CoordGrid;
+
+public interface EntityAPI {
+
+	public void moveTo (Entity entity, CoordGrid coords);
+	
+	public void setCoords(Entity entity, CoordGrid coords);
+	
+	/**
+	 * Retrieves the current coordinates of the specified entity
+	 * @param entity The entity to check
+	 * @return The entities current coordinates
+	 */
+	public CoordGrid getCoords (Entity entity);
+	
+	/**
+	 * Makes the entity display the specified message above their head
+	 * @param entity The entity to say the message
+	 * @param message The message to say
+	 */
+	public void say (Entity entity, String message);
+	
+	/**
+	 * Gets the name of the entity
+	 * @param entity The entity
+	 * @return The name
+	 */
+	public String getName (Entity entity);
+	
+	/**
+	 * Gradually moves the entity from it's current coordinates to the target coords.
+	 * The movement will take place gradually over the specified length, in client cycles.
+	 * Approximately after the move is complete, the entitie's coordinates will be set to {@code coords}
+	 * @param entity The entity to move
+	 * @param coords The coordinates to move to
+	 * @param length The number of client cycles required to perform the move
+	 */
+	public void forceMove (Entity entity, CoordGrid coords, int length);
+	
+	/**
+	 * Gradually moves the entity from it's current coordinates to the final coords, via the intermediate coords.
+	 * Moves from start to intermediate over {@code intermediateDelay}, then to final over {@code totalLength}
+	 * @param entity The entity to move
+	 * @param intermediateCoords The intermediate coordinates to move to
+	 * @param intermediateDelay The time taken to move to the intermediate coords
+	 * @param finalCoords The final coordinates to move to
+	 * @param totalLength The total time taken to move from the current coords to the final coords
+	 * @param facingCoords The coordinates to face after performing the move
+	 */
+	public void forceMove (Entity entity, CoordGrid intermediateCoords, int intermediateDelay, 
+			CoordGrid finalCoords, int totalLength, CoordGrid facingCoords);
+}

--- a/src/main/java/org/virtue/engine/script/api/ScriptAPI.java
+++ b/src/main/java/org/virtue/engine/script/api/ScriptAPI.java
@@ -988,8 +988,6 @@ public interface ScriptAPI {
 	 */
 	public void clearFaceEntity (Entity entity);
 	
-	public void forceMovement (Entity entity, CoordGrid t1, int delay1, CoordGrid t2, int delay2, int direction);
-	
 	/**
 	 * Moves the entity to the specified coordinates
 	 * @param entity The entity to teleport

--- a/src/main/java/org/virtue/engine/script/api/impl/VirtueEntityAPI.java
+++ b/src/main/java/org/virtue/engine/script/api/impl/VirtueEntityAPI.java
@@ -1,0 +1,53 @@
+package org.virtue.engine.script.api.impl;
+
+import org.virtue.engine.script.api.EntityAPI;
+import org.virtue.game.entity.Entity;
+import org.virtue.game.map.CoordGrid;
+import org.virtue.network.protocol.update.block.ForceMovementBlock;
+import org.virtue.network.protocol.update.block.TalkBlock;
+
+public class VirtueEntityAPI implements EntityAPI {
+
+	public VirtueEntityAPI() {
+		// TODO Auto-generated constructor stub
+	}
+
+	@Override
+	public void moveTo(Entity entity, CoordGrid coords) {
+		entity.getMovement().moveTo(coords.getX(), coords.getY());
+	}
+
+	@Override
+	public void setCoords(Entity entity, CoordGrid coords) {
+		entity.getMovement().setCoords(coords);
+	}
+
+	@Override
+	public CoordGrid getCoords(Entity entity) {
+		return entity.getCurrentTile();
+	}
+
+	@Override
+	public void say(Entity entity, String message) {
+		entity.queueUpdateBlock(new TalkBlock(message));
+	}
+
+	@Override
+	public String getName(Entity entity) {
+		return entity.getName();
+	}
+
+	@Override
+	public void forceMove(Entity entity, CoordGrid coords, int length) {
+		forceMove(entity, entity.getCurrentTile(), 0, coords, length, coords);
+	}
+
+	@Override
+	public void forceMove(Entity entity, CoordGrid fromCoords, int delay, CoordGrid finalCoords, int totalLength, CoordGrid facingCoords) {
+		entity.queueUpdateBlock(new ForceMovementBlock(fromCoords, delay, finalCoords, totalLength, facingCoords));
+		entity.addDelayTask(() -> {
+			entity.getMovement().setCoords(finalCoords);
+		}, (totalLength / 30) + 1);
+	}
+
+}

--- a/src/main/java/org/virtue/engine/script/api/impl/VirtueScriptAPI.java
+++ b/src/main/java/org/virtue/engine/script/api/impl/VirtueScriptAPI.java
@@ -67,10 +67,9 @@ import org.virtue.game.entity.player.inv.Item;
 import org.virtue.game.entity.player.stat.Stat;
 import org.virtue.game.entity.player.var.VarContainer;
 import org.virtue.game.entity.player.widget.WidgetManager;
+import org.virtue.game.map.CoordGrid;
 import org.virtue.game.map.GroundItem;
 import org.virtue.game.map.SceneLocation;
-import org.virtue.game.map.CoordGrid;
-import org.virtue.game.map.movement.CompassPoint;
 import org.virtue.game.map.square.MapSquare;
 import org.virtue.game.node.Node;
 import org.virtue.game.node.ServerNode;
@@ -78,7 +77,6 @@ import org.virtue.game.parser.AccountIndex;
 import org.virtue.game.parser.AccountInfo;
 import org.virtue.network.protocol.update.block.FaceDirectionBlock;
 import org.virtue.network.protocol.update.block.FaceEntityBlock;
-import org.virtue.network.protocol.update.block.ForceMovementBlock;
 import org.virtue.network.protocol.update.block.ForceTalkBlock;
 import org.virtue.network.protocol.update.block.SpotAnimationBlock;
 import org.virtue.network.protocol.update.block.TalkBlock;
@@ -1718,14 +1716,6 @@ public class VirtueScriptAPI implements ScriptAPI {
 	@Override
 	public void clearFaceEntity(Entity entity) {
 		entity.queueUpdateBlock(new FaceEntityBlock(null));
-	}
-
-	/* (non-Javadoc)
-	 * @see org.virtue.engine.script.ScriptAPI#forceMovement(org.virtue.game.entity.Entity, org.virtue.game.entity.region.Tile, int, org.virtue.game.entity.region.Tile, int, int)
-	 */
-	@Override
-	public void forceMovement(Entity entity, CoordGrid t1, int delay1, CoordGrid t2, int delay2, int direction) {
-		entity.queueUpdateBlock(new ForceMovementBlock(t1, delay1, CompassPoint.getById(direction), t2, delay2));
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/org/virtue/network/protocol/update/block/ForceMovementBlock.java
+++ b/src/main/java/org/virtue/network/protocol/update/block/ForceMovementBlock.java
@@ -24,7 +24,6 @@ package org.virtue.network.protocol.update.block;
 import org.virtue.game.entity.Entity;
 import org.virtue.game.entity.player.Player;
 import org.virtue.game.map.CoordGrid;
-import org.virtue.game.map.movement.CompassPoint;
 import org.virtue.network.event.buffer.OutboundBuffer;
 import org.virtue.network.protocol.update.Block;
 import org.virtue.network.protocol.update.BlockType;
@@ -35,27 +34,23 @@ import org.virtue.network.protocol.update.BlockType;
  */
 public class ForceMovementBlock extends Block {
 
-	private CoordGrid tile1;
-	private int delay1;
-	private CoordGrid tile2;
-	private int delay2;
+	private CoordGrid intermediateCoords;
+	private int intermediateDelay;
+	private CoordGrid finalCoords;
+	private int finalDelay;
 
-	private CompassPoint direction;
-
-	public ForceMovementBlock(CoordGrid tile1, int delay1, CompassPoint direction) {
-		this(tile1, delay1, direction, tile1, delay1+1);
-	}
+	private CoordGrid facing;
 
 	/**
 	 * The {@link ForceMovementBlock} constructor
 	 */
-	public ForceMovementBlock(CoordGrid tile1, int delay1, CompassPoint direction, CoordGrid tile2, int delay2) {
+	public ForceMovementBlock(CoordGrid fromCoords, int delay, CoordGrid toCoords, int length, CoordGrid facing) {
 		super(BlockType.MOVE);
-		this.tile1 = tile1;
-		this.delay1 = delay1;
-		this.tile2 = tile2;
-		this.delay2 = delay2;
-		this.direction = direction;
+		this.intermediateCoords = fromCoords;
+		this.intermediateDelay = delay;
+		this.finalCoords = toCoords;
+		this.finalDelay = length;
+		this.facing = facing;
 	}
 
 	/* (non-Javadoc)
@@ -63,26 +58,27 @@ public class ForceMovementBlock extends Block {
 	 */
 	@Override
 	public void encodeBlock(OutboundBuffer block, Entity entity) {
+		int direction = ((int) (Math.atan2(entity.getCurrentTile().getX() - facing.getX(), entity.getCurrentTile().getY() - facing.getY()) * 2607.5945876176133)) & 0x3fff;
 		if (entity instanceof Player) {
-			block.putA(tile1.getX() - entity.getCurrentTile().getX());
-			block.putA(tile1.getY() - entity.getCurrentTile().getY());
-			block.putC(tile2.getX() - entity.getCurrentTile().getX());
-			block.putA(tile2.getY() - entity.getCurrentTile().getY());
-			block.putA(tile1.getLevel() - entity.getCurrentTile().getLevel());
-			block.putA(tile2.getLevel() - entity.getCurrentTile().getLevel());
-			block.putShortA(delay1 * 30);
-			block.putLEShortA(delay2 * 30);
-			block.putLEShortA(this.direction.getID());
+			block.putA(intermediateCoords.getX() - entity.getCurrentTile().getX());
+			block.putA(intermediateCoords.getY() - entity.getCurrentTile().getY());
+			block.putC(finalCoords.getX() - entity.getCurrentTile().getX());
+			block.putA(finalCoords.getY() - entity.getCurrentTile().getY());
+			block.putA(intermediateCoords.getLevel() - entity.getCurrentTile().getLevel());
+			block.putA(finalCoords.getLevel() - entity.getCurrentTile().getLevel());
+			block.putShortA(intermediateDelay);
+			block.putLEShortA(finalDelay);
+			block.putLEShortA(direction);
 		} else {
-			block.putC(tile1.getX() - entity.getCurrentTile().getX());
-			block.putS(tile1.getY() - entity.getCurrentTile().getY());
-			block.putByte(tile2.getX() - entity.getCurrentTile().getX());
-			block.putA(tile2.getY() - entity.getCurrentTile().getY());
-			block.putS(tile1.getLevel() - entity.getCurrentTile().getLevel());
-			block.putA(tile2.getLevel() - entity.getCurrentTile().getLevel());
-			block.putShortA(delay1 * 30);
-			block.putShort(delay2 * 30);
-			block.putLEShort(this.direction.getID());
+			block.putC(intermediateCoords.getX() - entity.getCurrentTile().getX());
+			block.putS(intermediateCoords.getY() - entity.getCurrentTile().getY());
+			block.putByte(finalCoords.getX() - entity.getCurrentTile().getX());
+			block.putA(finalCoords.getY() - entity.getCurrentTile().getY());
+			block.putS(intermediateCoords.getLevel() - entity.getCurrentTile().getLevel());
+			block.putA(finalCoords.getLevel() - entity.getCurrentTile().getLevel());
+			block.putShortA(intermediateDelay);
+			block.putShort(finalDelay);
+			block.putLEShort(direction);
 		}
 	}
 


### PR DESCRIPTION
See `testDelayedMovement` in `test-commands.js` for example usage. 

Note: in this implementation, there's no need to manually set the entity's coords after the movement finishes - it's done automatically. Also note the duration are specified in **client cycles**, not server cycles.