### PR TITLE
Fixed 'tried to load var_player...' errors & tidied up variable storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.21'
     compile 'com.google.code.gson:gson:2.3'
-    compile 'com.google.guava:guava:18.0'
+    compile 'com.google.guava:guava:22.0'
     compile 'io.netty:netty-all:4.0.26.Final'
     
     testCompile "junit:junit:4.11"

--- a/src/main/java/org/virtue/config/ConfigNotFoundException.java
+++ b/src/main/java/org/virtue/config/ConfigNotFoundException.java
@@ -1,0 +1,11 @@
+package org.virtue.config;
+
+public class ConfigNotFoundException extends RuntimeException {
+
+	private static final long serialVersionUID = -6671532492589207828L;
+
+	public ConfigNotFoundException(Js5ConfigGroup group, int id) {
+		super("Config item "+group.name().toLowerCase()+" "+id+" does not exist");
+	}
+
+}

--- a/src/main/java/org/virtue/config/vartype/VarType.java
+++ b/src/main/java/org/virtue/config/vartype/VarType.java
@@ -133,4 +133,8 @@ public class VarType implements ConfigType {
 		
 	}
 
+	@Override
+	public String toString () {
+		return debugName != null ? debugName : Integer.toString(id);
+	}
 }

--- a/src/main/java/org/virtue/config/vartype/general/VarBasicTypeList.java
+++ b/src/main/java/org/virtue/config/vartype/general/VarBasicTypeList.java
@@ -56,7 +56,7 @@ public class VarBasicTypeList extends VarTypeList {
 	 * @see org.virtue.config.ConfigDecoder#load(java.lang.Integer)
 	 */
 	@Override
-	public VarType load(Integer id) throws Exception {
+	protected VarType load(int id) throws Exception {
 		ByteBuffer data = getData(id);
 		if (data == null) {
 			return null;

--- a/src/main/java/org/virtue/game/entity/player/interactions/PlayerExamineHandler.java
+++ b/src/main/java/org/virtue/game/entity/player/interactions/PlayerExamineHandler.java
@@ -71,7 +71,7 @@ public class PlayerExamineHandler implements PlayerOptionHandler {
 			clan = "None";
 		}
 		player.getDispatcher().sendVarcString(VarKey.Client.PLAYER_INSPECT_CLAN, clan);
-		String message = (String) player.getVars().getVarValue(VarKey.Player.PLAYER_INSPECT_MESSAGE);
+		String message = (String) player.getVars().getVarValueLegacy(VarKey.Player.PLAYER_INSPECT_MESSAGE);
 		if (message != null) {
 			player.getDispatcher().sendVarcString(VarKey.Client.PLAYER_INSPECT_MESSAGE, message);
 		}

--- a/src/main/java/org/virtue/game/entity/player/var/DefaultVars.java
+++ b/src/main/java/org/virtue/game/entity/player/var/DefaultVars.java
@@ -30,7 +30,7 @@ package org.virtue.game.entity.player.var;
  */
 public class DefaultVars {
 
-	public static void setDefaultVarps(int[] varps) {
+	public static void setDefaultVarps(Object[] varps) {
 		varps[2] = 16384;
 		varps[3] = -1469706249;
 		varps[4] = 2048;


### PR DESCRIPTION
Not a particularly exciting fix, but this finally gets rid of the `Tried to load var_player 3484 which does not exist!` warning messages on player login. It also cleans up some of the methods around variables & configuration so we're not storing more than we need to.