### PR TITLE
Fixed cascading map square loads

### DIFF
--- a/src/main/java/org/virtue/game/map/square/RegionManager.java
+++ b/src/main/java/org/virtue/game/map/square/RegionManager.java
@@ -248,7 +248,7 @@ public class RegionManager {
 	 */
 	public int getClippingFlag(int level, int x, int y) {
 		CoordGrid tile = new CoordGrid(x, y, level);
-		MapSquare region = getRegionByID(tile.getRegionID());
+		MapSquare region = getWithoutLoad(tile.getRegionID());
 		if (region == null || !region.isLoaded()) {
 			return -1;
 		}


### PR DESCRIPTION
This really simple change prevents the loading of one map square causing the loading of more map squares, causing the loading of even more, and so on due to NPC movements. Now, only a player moving onto a new map square will cause it to be loaded (saving memory & CPU)