### PR TITLE
Prevent NPCs from being loaded multiple times due to map square reloads

### DIFF
--- a/src/main/java/org/virtue/game/map/square/MapSquare.java
+++ b/src/main/java/org/virtue/game/map/square/MapSquare.java
@@ -476,6 +476,7 @@ public class MapSquare {
 	 */
 	public void removeNpc (NPC npc) {
 		npcs.remove(npc);
+		World.getInstance().removeNPC(npc);
 	}
 	
 	/**
@@ -504,6 +505,13 @@ public class MapSquare {
 	
 	public boolean canUnload () {
 		return players.isEmpty();
+	}
+	
+	public void unload () {
+		for (NPC npc : npcs) {
+			World.getInstance().removeNPC(npc);
+		}
+		npcs.clear();
 	}
 	
 	public Set<Player> getPlayers () {

--- a/src/main/java/org/virtue/game/map/square/RegionManager.java
+++ b/src/main/java/org/virtue/game/map/square/RegionManager.java
@@ -164,8 +164,8 @@ public class RegionManager {
 		synchronized (regions) {
 			for (MapSquare r : removalQueue) {
 				emptyRegions.remove(r);
-				if (r.canUnload()) {// Double check that nothing has spawned in
-									// the region since the last rotation
+				if (r.canUnload()) {// Double check that nothing has spawned in the region since the last rotation
+					r.unload();
 					regions.remove(r.getID());
 				}
 			}

--- a/src/main/java/org/virtue/game/map/square/load/MapLoader.java
+++ b/src/main/java/org/virtue/game/map/square/load/MapLoader.java
@@ -94,7 +94,6 @@ public final class MapLoader {
 		} else if (extraData != null && extraData.fileExists(groupId, MapsFile.NPC_SPAWNS)) {
 			square.setLoadStage(LoadStage.LOADING_NPCS);
 			extraNpcCount = npcLoader.loadNpcs(extraData.getFile(groupId, MapsFile.NPC_SPAWNS), square);
-			LOGGER.info("Loaded {} extra NPCs from extra data", extraNpcCount);
 		}
 
 		square.setLoadStage(LoadStage.COMPLETED);

--- a/src/main/java/org/virtue/io/sqlite/SqliteCache.java
+++ b/src/main/java/org/virtue/io/sqlite/SqliteCache.java
@@ -48,7 +48,7 @@ public class SqliteCache implements ResourceProvider, AutoCloseable {
 		} catch (ExecutionException e) {
 			throw (IOException) e.getCause();
 		}
-		return archive.getEntry(getIndex().getEntry(groupId, fileId).index());
+		return archive.getEntry(getIndex().getEntry(groupId, fileId).index()).asReadOnlyBuffer();
 	}
 
 	@Override


### PR DESCRIPTION
This is only really a work-around fix, as it means NPCs will be removed even if they've roamed onto a different map square, but at least it means we won't have duplicated NPCs.

Long term a better solution for NPC loading/unloading will be needed, especially when dealing with NPCs who have a large roam range (e.g. implings, penguins, etc).