### PR TITLE
Replacement location refactor

### DIFF
--- a/repository/scripts/area/location-picking.js
+++ b/repository/scripts/area/location-picking.js
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 /* globals EventType */
+var _map = require('engine/map');
+
 var anim = require('anim');
 var util = require('util');
 var dialog = require('dialog');
@@ -27,78 +29,96 @@ var inv = require('inv');
 var map = require('map');
 var loc = require('map/location');
 var chat = require('chat');
+
 module.exports = (function () {
 	return {
 		init : init
 	};
-	
+
 	function init (scriptManager) {
-		
 		scriptManager.bind(EventType.OPLOC2, [ 2646, 67263, 67264, 67265 ], function (ctx) {//flax
 			if(util.mapMembers()){
-	            anim.run(ctx.player, 827, function () {
-				inv.give(ctx.player, 1779, 1);	
-			    loc.delay(loc.add(-1, map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location)), 60, function () {
-			    loc.add(util.getId(ctx.location), map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location));
-		        });
-			    });	
-            } else {
-                dialog.mesbox(ctx.player, "Only members can pick flax."); 
-            }
+				anim.run(ctx.player, 827, function () {
+					inv.give(ctx.player, 1779, 1);
+					var coord = map.getCoords(ctx.location);
+					var shape = loc.getShape(ctx.location);
+					var rotation = loc.getRotation(ctx.location);
+					_map.delay(coord, function () {
+						_map.addLoc(util.getId(ctx.location), coord, shape, rotation);
+					}, 60);
+				});
+			} else {
+				dialog.mesbox(ctx.player, "Only members can pick flax."); 
+			}
 		});
 
 		scriptManager.bind(EventType.OPLOC2, [ 15506, 15507, 15508 ], function (ctx) {//wheat
-	        anim.run(ctx.player, 827, function () {
-			chat.sendMessage(ctx.player, "You pick some wheat.");
-			inv.give(ctx.player, 1947, 1);	
-			loc.delay(loc.add(-1, map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location)), 60, function () {
-			loc.add(util.getId(ctx.location), map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location));
-		    });
-			});	
+			anim.run(ctx.player, 827, function () {
+				chat.sendMessage(ctx.player, "You pick some wheat.");
+				inv.give(ctx.player, 1947, 1);
+				var coord = map.getCoords(ctx.location);
+				var shape = loc.getShape(ctx.location);
+				var rotation = loc.getRotation(ctx.location);
+				_map.delay(coord, function () {
+					_map.addLoc(util.getId(ctx.location), coord, shape, rotation);
+				}, 60);
+			});
 		});
-		
+
 		scriptManager.bind(EventType.OPLOC2, 1161, function (ctx) {//cabbage
-	        anim.run(ctx.player, 827, function () {
-			chat.sendMessage(ctx.player, "You pick a cabbage.");
-			inv.give(ctx.player, 1965, 1);	
-			loc.delay(loc.add(-1, map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location)), 60, function () {
-			loc.add(util.getId(ctx.location), map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location));
-		    });
-			});	
+			anim.run(ctx.player, 827, function () {
+				chat.sendMessage(ctx.player, "You pick a cabbage.");
+				inv.give(ctx.player, 1965, 1);
+				var coord = map.getCoords(ctx.location);
+				var shape = loc.getShape(ctx.location);
+				var rotation = loc.getRotation(ctx.location);
+				_map.delay(coord, function () {
+					_map.addLoc(util.getId(ctx.location), coord, shape, rotation);
+				}, 60);
+			});
 		});
-		
-		scriptManager.bind(EventType.OPLOC1, [86687,86688,86689, 86690, 86691], function (ctx) {//cabbage
-	        anim.run(ctx.player, 827);
+
+		scriptManager.bind(EventType.OPLOC1, [ 86687,86688,86689, 86690, 86691 ], function (ctx) {//cabbage
+			anim.run(ctx.player, 827);
 			inv.give(ctx.player, 1965, 1);	
 		});
-		
+
 		scriptManager.bind(EventType.OPLOC1, 11494, function (ctx) {//cabbage
-	        anim.run(ctx.player, 827, function () {
-			chat.sendMessage(ctx.player, "You pick a cabbage.");
-			inv.give(ctx.player, 1967, 1);	
-			loc.delay(loc.add(-1, map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location)), 60, function () {
-			loc.add(util.getId(ctx.location), map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location));
-		    });
+			anim.run(ctx.player, 827, function () {
+				chat.sendMessage(ctx.player, "You pick a cabbage.");
+				inv.give(ctx.player, 1967, 1);
+				var coord = map.getCoords(ctx.location);
+				var shape = loc.getShape(ctx.location);
+				var rotation = loc.getRotation(ctx.location);
+				_map.delay(coord, function () {
+					_map.addLoc(util.getId(ctx.location), coord, shape, rotation);
+				}, 60);
 			});
 		});
-		
+
 		scriptManager.bind(EventType.OPLOC2, 3366, function (ctx) {//Onion
-	        anim.run(ctx.player, 827, function () {
-			inv.give(ctx.player, 1957, 1);	
-			chat.sendMessage(ctx.player, "You pick a onion.");
-			loc.delay(loc.add(-1, map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location)), 60, function () {
-			loc.add(util.getId(ctx.location), map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location));
-		    });
+			anim.run(ctx.player, 827, function () {
+				chat.sendMessage(ctx.player, "You pick a onion.");
+				inv.give(ctx.player, 1957, 1);
+				var coord = map.getCoords(ctx.location);
+				var shape = loc.getShape(ctx.location);
+				var rotation = loc.getRotation(ctx.location);
+				_map.delay(coord, function () {
+					_map.addLoc(util.getId(ctx.location), coord, shape, rotation);
+				}, 60);
 			});
 		});
-		
+
 		scriptManager.bind(EventType.OPLOC2, 312, function (ctx) {//Potato
-	        anim.run(ctx.player, 827, function () {
-			chat.sendMessage(ctx.player, "You pick a potato.");
-			inv.give(ctx.player, 1942, 1);	
-			loc.delay(loc.add(-1, map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location)), 60, function () {
-			loc.add(util.getId(ctx.location), map.getCoords(ctx.location), loc.getShape(ctx.location), loc.getRotation(ctx.location));
-		    });
+			anim.run(ctx.player, 827, function () {
+				chat.sendMessage(ctx.player, "You pick a potato.");
+				inv.give(ctx.player, 1942, 1);
+				var coord = map.getCoords(ctx.location);
+				var shape = loc.getShape(ctx.location);
+				var rotation = loc.getRotation(ctx.location);
+				_map.delay(coord, function () {
+					_map.addLoc(util.getId(ctx.location), coord, shape, rotation);
+				}, 60);
 			});
 		});
 	}

--- a/repository/scripts/node_modules/engine/map.js
+++ b/repository/scripts/node_modules/engine/map.js
@@ -19,7 +19,8 @@ module.exports = (function () {
 		rotateZone : rotateZone,
 		build : build,
 		addLoc : addLoc,
-		delLoc : delLoc
+		delLoc : delLoc,
+		delay : delay
 	};
 
 	function getCoords (node) {
@@ -80,5 +81,9 @@ module.exports = (function () {
 
 	function delLoc (coord, shape, rotation) {
 		MAP_ENGINE.delLoc(coord, shape, rotation);
+	}
+
+	function delay (coord, task, ticks) {
+		MAP_ENGINE.delay(coord, task, ticks);
 	}
 })();

--- a/repository/scripts/skill/firemaking/lighting.js
+++ b/repository/scripts/skill/firemaking/lighting.js
@@ -21,6 +21,7 @@
  */
 /* globals Stat, Inv */
 var _entity = require('engine/entity');
+var _map = require('engine/map');
 
 var stat = require('stat');
 var chat = require('chat');
@@ -75,10 +76,11 @@ module.exports = (function () {
 
 	function firemakingSuccess (player, logType) {
 		map.takeObj(logType.logId, map.getCoords(player));
-		var loc = map.addLoc(logType.fireId, map.getCoords(player), 10, 0);//Spawn the fire
-		map.delayLoc(loc, logType.duration, function () {
-			map.delLoc(loc);
-		});
+		var coord = _map.getCoords(player);
+		var loc = _map.addLoc(logType.fireId, coord, 10, 0);//Spawn the fire
+		_map.delay(coord, function () {
+			_map.delLoc(loc);
+		}, logType.duration);
 		_entity.moveAdjacent(player);
 		stat.giveXp(player, Stat.FIREMAKING, logType.xp);//Add firemaking xp
 		chat.sendSpamMessage(player, "The fire catches and the logs begin to burn.");

--- a/repository/scripts/skill/mining/basic.js
+++ b/repository/scripts/skill/mining/basic.js
@@ -20,7 +20,9 @@
  * SOFTWARE.
  */
 /* globals EventType, Stat */
-var config = require('engine/config');
+var _config = require('engine/config');
+var _map = require('engine/map');
+
 var util = require('util');
 var chat = require('chat');
 var inv = require('inv');
@@ -225,7 +227,7 @@ module.exports = (function () {
 				mineRock(ctx.player, ctx.location, RockType.RUNITE);
 		});
 	}
-	
+
 	function mineRock(player, location, rockType) {
 		if (!inv.hasSpace(player)) {
 			chat.sendMessage(player, "Not enough space in your inventory.");
@@ -236,34 +238,33 @@ module.exports = (function () {
 			setEmpty(player, location, rockType.respawnDelay);
 			
 			inv.give(player, rockType.oreId, 1);
-			chat.sendSpamMessage(player, "You mine some " + config.objName(rockType.oreId) + ".");
+			chat.sendSpamMessage(player, "You mine some " + _config.objName(rockType.oreId) + ".");
 		});
 	}
-	
+
 	function setEmpty (player, location, respawnDelay) {
 		var rockCoords = map.getCoords(location);
 		var fullId = util.getId(location);
 		var emptyId = getEmptyId(player, fullId);
 		var rotation = loc.getRotation(location);
 		var shape = loc.getShape(location);
-		
-		var emptyRock = loc.add(emptyId, rockCoords, shape, rotation);
-		
-		loc.delay(emptyRock, respawnDelay, function () {
+
+		loc.add(emptyId, rockCoords, shape, rotation);
+		_map.delay(rockCoords, function () {
 			loc.add(fullId, rockCoords, shape, rotation);
-		});
+		}, respawnDelay);
 	}
-	
+
 	function getEmptyId (player, locTypeId) {
-		if (config.locHasModel(locTypeId, 65251)) {
+		if (_config.locHasModel(locTypeId, 65251)) {
 			return 5765;
-		} else if (config.locHasModel(locTypeId, 65253)) {
+		} else if (_config.locHasModel(locTypeId, 65253)) {
 			return 5764;
-		} else if (config.locHasModel(locTypeId, 65252)) {
+		} else if (_config.locHasModel(locTypeId, 65252)) {
 			return 5763;
-		} else if (config.locHasModel(locTypeId, 99106)) {
+		} else if (_config.locHasModel(locTypeId, 99106)) {
 			return 93014;
-		} else if (config.locHasModel(locTypeId, 99109)) {
+		} else if (_config.locHasModel(locTypeId, 99109)) {
 			return 93015;
 		} else {
 			chat.sendDebugMessage(player, "Warning: No empty rock mesh for location "+locTypeId);

--- a/repository/scripts/skill/woodcutting/basic.js
+++ b/repository/scripts/skill/woodcutting/basic.js
@@ -22,6 +22,7 @@
 /* globals EventType, Stat */
 var coords = require('map/coords');
 var _config = require('engine/config');
+var _map = require('engine/map');
 
 var util = require('util');
 var chat = require('chat');
@@ -353,13 +354,12 @@ module.exports = (function () {
 			locMap.del(treeTop);
 		}
 
-		var treeStump = locMap.add(stumpId, treeCoords, shape, rotation);
-		
-		locMap.delay(treeStump, respawnDelay, function () {
+		locMap.add(stumpId, treeCoords, shape, rotation);
+		_map.delay(treeCoords, function () {
 			locMap.add(treeId, treeCoords, shape, rotation);
 			if (treeTop) {
 				locMap.add(util.getId(treeTop), map.getCoords(treeTop), shape, locMap.getRotation(treeTop));
 			}
-		});
+		}, respawnDelay);
 	}
 })();

--- a/src/main/java/org/virtue/engine/script/api/MapAPI.java
+++ b/src/main/java/org/virtue/engine/script/api/MapAPI.java
@@ -258,12 +258,23 @@ public interface MapAPI {
 
 	/**
 	 * Delays the execution of a task by the given number of server cycles.
-	 * The task will be cancelled if the location is destroyed
-	 * @param loc The location to delay on
+	 * The task will be cancelled if the map square the node is currently on is destroyed
+	 * @param node The node to retrieve the map square coord from
 	 * @param task The task to run after the delay
 	 * @param ticks The number of server cycles to delay by
 	 */
-	public void delay (SceneLocation loc, Runnable task, int ticks);
+	public default void delay (Node node, Runnable task, int ticks) {
+		delay(node.getCurrentTile(), task, ticks);
+	}
+
+	/**
+	 * Delays the execution of a task by the given number of server cycles.
+	 * The task will be cancelled if the map square is destroyed
+	 * @param mapSquareCoord The coordinate of the map square to run this task in
+	 * @param task The task to run after the delay
+	 * @param ticks The number of server cycles to delay by
+	 */
+	public void delay (CoordGrid mapSquareCoord, Runnable task, int ticks);
 
 	/**
 	 * Adds an item to the map at the given coordinates.

--- a/src/main/java/org/virtue/engine/script/api/impl/VirtueMapAPI.java
+++ b/src/main/java/org/virtue/engine/script/api/impl/VirtueMapAPI.java
@@ -250,8 +250,12 @@ public class VirtueMapAPI implements MapAPI {
 	}
 
 	@Override
-	public void delay(SceneLocation loc, Runnable task, int ticks) {
-		loc.addDelayTask(task, ticks);
+	public void delay(CoordGrid mapSquareCoord, Runnable task, int ticks) {
+		MapSquare mapSquare = getRegion(mapSquareCoord);
+		if (mapSquare == null) {
+			throw new IllegalArgumentException("Invalid coords: "+mapSquareCoord);
+		}
+		mapSquare.queueTask(task, ticks);
 	}
 
 	@Override

--- a/src/main/java/org/virtue/game/map/SceneLocation.java
+++ b/src/main/java/org/virtue/game/map/SceneLocation.java
@@ -21,9 +21,6 @@
  */
 package org.virtue.game.map;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.virtue.Virtue;
 import org.virtue.config.loctype.LocShape;
 import org.virtue.config.loctype.LocType;

--- a/src/main/java/org/virtue/game/map/SceneLocation.java
+++ b/src/main/java/org/virtue/game/map/SceneLocation.java
@@ -39,11 +39,6 @@ import org.virtue.network.event.context.impl.in.OptionButton;
  */
 public class SceneLocation extends Node {
 
-	private static class DelayTask {
-		private int delayTime;
-		private Runnable onFinish;		
-	}
-
 	public static SceneLocation createBase (int id, CoordGrid tile, LocShape shape, int rotation) {
 		SceneLocation location = new SceneLocation(id, tile, shape, rotation);
 		location.replacement = false;
@@ -62,8 +57,6 @@ public class SceneLocation extends Node {
 	private boolean replacement = true;
 
 	private LocType locType;
-
-	private Set<DelayTask> delayTasks = new HashSet<>();
 
 	protected SceneLocation (int id, CoordGrid tile, LocShape shape, int rotation) {
 		super(id);
@@ -92,22 +85,6 @@ public class SceneLocation extends Node {
 	 */
 	public int getID () {
 		return id;
-	}
-	
-	public synchronized void processTick () {
-		Set<DelayTask> tasks = delayTasks;
-		delayTasks = new HashSet<>();
-		for (DelayTask task : tasks) {
-			task.delayTime--;
-			if (task.delayTime > 0) {
-				delayTasks.add(task);
-			} else {
-				if (task.onFinish != null) {
-					task.onFinish.run();
-				}
-				delayTasks.remove(task);
-			}
-		}
 	}
 
 	/**
@@ -220,13 +197,6 @@ public class SceneLocation extends Node {
 		} else {
 			return false;
 		}
-	}
-
-	public synchronized void addDelayTask (Runnable onFinish, int delay) {
-		DelayTask task = new DelayTask();
-		task.onFinish = onFinish;
-		task.delayTime = delay;
-		delayTasks.add(task);
 	}
 
 	@Override

--- a/src/main/java/org/virtue/game/map/square/DynamicMapSquare.java
+++ b/src/main/java/org/virtue/game/map/square/DynamicMapSquare.java
@@ -59,11 +59,17 @@ public class DynamicMapSquare extends MapSquare {
 	/**
 	 * Clears all locations, objects, and terrain clipping from the map square in preparation for a rebuild
 	 */
-	public void reset () {
+	public void preRebuild () {
 		synchronized (zones) {
-			zones.clear();
+			zones.values().forEach(zone -> zone.preRebuild());
 		}
 		getClipMap().reset();
+	}
+
+	public void postRebuild () {
+		synchronized (zones) {
+			zones.values().forEach(zone -> zone.postRebuild());
+		}
 	}
 
 	public void rotateZone (int zoneX, int zoneY, int level, int rotation) {

--- a/src/main/java/org/virtue/game/map/square/LocationReplacement.java
+++ b/src/main/java/org/virtue/game/map/square/LocationReplacement.java
@@ -1,0 +1,35 @@
+package org.virtue.game.map.square;
+
+import org.virtue.game.map.CoordGrid;
+import org.virtue.game.map.SceneLocation;
+
+public class LocationReplacement {
+
+	private SceneLocation original;
+
+	private final SceneLocation replacement;
+
+	public LocationReplacement(SceneLocation replacement) {
+		this.replacement = replacement;
+	}
+
+	public SceneLocation getOriginal() {
+		return original;
+	}
+
+	public void setOriginal(SceneLocation original) {
+		this.original = original;
+	}
+
+	public SceneLocation getReplacement() {
+		return replacement;
+	}
+
+	public CoordGrid getCoord () {
+		return replacement.getTile();
+	}
+
+	public int getLayer () {
+		return replacement.getShape().getLayer();
+	}
+}

--- a/src/main/java/org/virtue/game/map/square/Zone.java
+++ b/src/main/java/org/virtue/game/map/square/Zone.java
@@ -32,6 +32,7 @@ import org.virtue.network.event.encoder.impl.ZoneUpdateEventEncoder;
  * @since 5/11/2014
  */
 public class Zone {
+
 	/**
 	 * Base locations which have been replaced
 	 */
@@ -151,11 +152,6 @@ public class Zone {
 	}
 
 	protected void updateBlock (Iterable<Player> players) {
-		Iterator<SceneLocation> locIterator = locations.values().iterator();
-		while (locIterator.hasNext()) {
-			SceneLocation loc = locIterator.next();
-			loc.processTick();
-		}
 		for (List<GroundItem> itemSet : items.values()) {
 			Iterator<GroundItem> iterator = itemSet.iterator();
 			GroundItem item;

--- a/src/main/java/org/virtue/game/map/square/Zone.java
+++ b/src/main/java/org/virtue/game/map/square/Zone.java
@@ -34,11 +34,6 @@ import org.virtue.network.event.encoder.impl.ZoneUpdateEventEncoder;
 public class Zone {
 
 	/**
-	 * Base locations which have been replaced
-	 */
-	private final Map<Integer, SceneLocation> replacedLocations = new HashMap<>();
-
-	/**
 	 * Represents the ground items located within this block
 	 */
 	private final Map<Integer, List<GroundItem>> items = new HashMap<Integer, List<GroundItem>>();
@@ -47,6 +42,8 @@ public class Zone {
 	 * Locations currently active in the zone
 	 */
 	protected final Map<Integer, SceneLocation> locations = new HashMap<>();
+
+	private final Map<Integer, LocationReplacement> replacementLocations = new HashMap<>();
 
 	private CoordGrid coord;
 
@@ -59,50 +56,53 @@ public class Zone {
 		locations.put(hash, loc);
 	}
 
-	protected void updateLocation (SceneLocation loc) {
-		int hash = getLocationHash(loc);
-		if (replacedLocations.containsKey(hash)) {
-			if (Objects.equals(replacedLocations.get(hash), loc)) {
-				//We already have a base location at the same coords.
-				//Add it instead so we don't keep trying to send it to clients
-				locations.put(hash, replacedLocations.remove(hash));
-			} else {
-				//Otherwise, we're replacing another replacement.
-				//Don't worry about keeping the reference to it
-				locations.put(hash, loc);
-			}
+	/**
+	 * Adds or updates a location at the specified coords in the zone.
+	 * If the location is the same as the base, removes the replacement
+	 * If a base location already exists with the same coords & layer, retain it for future use
+	 * @param newLoc
+	 */
+	protected void updateLocation (SceneLocation newLoc) {
+		int hash = getLocationHash(newLoc);
+		SceneLocation original;
+		if (replacementLocations.containsKey(hash)) {
+			original = replacementLocations.remove(hash).getOriginal();
 		} else {
-			SceneLocation oldLoc = locations.put(hash, loc);
-			if (oldLoc != null && !oldLoc.isReplacement()) {
-				//Store the base location so it can be retrieved later
-				replacedLocations.put(hash, oldLoc);
-			}
+			original = locations.remove(hash);
+		}
+		if (Objects.equals(original, newLoc)) {
+			locations.put(hash, original);
+		} else {
+			LocationReplacement replacement = new LocationReplacement(newLoc);
+			replacement.setOriginal(original);
+			replacementLocations.put(hash, replacement);
+			locations.put(hash, newLoc);
 		}
 	}
 
 	protected void removeLocation (CoordGrid coord, LocShape shape, int rotation) {
-		int hash = getLocationHash(coord, shape, rotation);
-		if (replacedLocations.containsKey(hash)) {
-			//This change removed a base location, so we need to send the removal to new players
-			locations.put(hash, SceneLocation.create(-1, coord, shape, rotation));
-		} else {
-			SceneLocation oldLoc = locations.remove(hash);
-			if (oldLoc != null && !oldLoc.isReplacement()) {
-				//Store the old base location & send removal to new players
-				locations.put(hash, SceneLocation.create(-1, coord, shape, rotation));
-				replacedLocations.put(hash, oldLoc);
-			}
+		int hash = getLocationHash(coord, shape);
+		SceneLocation original = locations.remove(hash);
+		if (replacementLocations.containsKey(hash)) {
+			original = replacementLocations.remove(hash).getOriginal();
+		}
+		if (original != null) {
+			LocationReplacement replacement 
+				= new LocationReplacement(SceneLocation.create(-1, coord, shape, rotation));
+			replacement.setOriginal(original);
+			replacementLocations.put(hash, replacement);
 		}
 	}
 
 	protected Optional<SceneLocation> getLocation (CoordGrid coord, LocShape shape) {
-		return locations.values().stream()
-				.filter(loc -> loc.getTile().equals(coord) && loc.getShape() == shape).findAny();
+		int hash = getLocationHash(coord, shape);
+		return Optional.ofNullable(locations.get(hash));
 	}
 
 	protected Optional<SceneLocation> getLocation (CoordGrid coord, int locTypeId) {
 		return locations.values().stream()
-				.filter(loc -> loc.getTile().equals(coord) && loc.getId() == locTypeId).findAny();
+				.filter(loc -> loc.getId() == locTypeId && Objects.equals(loc.getTile(), coord))
+				.findAny();
 	}
 
 	protected void addItem (GroundItem item) {
@@ -151,6 +151,18 @@ public class Zone {
 		return selected;
 	}
 
+	protected void preRebuild () {
+		locations.clear();
+	}
+
+	public void postRebuild () {
+		replacementLocations.entrySet().forEach(entry -> {
+			LocationReplacement replacement = entry.getValue();
+			replacement.setOriginal(locations.remove(entry.getKey()));
+			locations.put(entry.getKey(), replacement.getReplacement());
+		});
+	}
+
 	protected void updateBlock (Iterable<Player> players) {
 		for (List<GroundItem> itemSet : items.values()) {
 			Iterator<GroundItem> iterator = itemSet.iterator();
@@ -179,8 +191,8 @@ public class Zone {
 				}
 			}
 		}
-		locations.values().stream()
-			.filter(SceneLocation::isReplacement)
+		replacementLocations.values().stream()
+			.map(LocationReplacement::getReplacement)
 			.forEach(loc -> {
 				if (loc.getId() < 0) {
 					packets.add(new DeleteLocation(loc));
@@ -194,11 +206,11 @@ public class Zone {
 	}
 
 	public int getLocationHash (SceneLocation loc) {
-		return getLocationHash(loc.getTile(), loc.getShape(), loc.getRotation());
+		return getLocationHash(loc.getTile(), loc.getShape());
 	}
 
-	public int getLocationHash (CoordGrid coord, LocShape shape, int rotation) {
-		return getLocalHash(coord) | rotation << 10 | shape.getId() << 12;
+	public int getLocationHash (CoordGrid coord, LocShape shape) {
+		return getLocalHash(coord) | shape.getLayer() << 10;
 	}
 
 	private int getLocalHash (CoordGrid coord) {

--- a/src/main/java/org/virtue/game/map/square/load/MapLoader.java
+++ b/src/main/java/org/virtue/game/map/square/load/MapLoader.java
@@ -114,8 +114,8 @@ public final class MapLoader {
 
 	public void loadDynamicMapSquare (DynamicMapSquare square) throws IOException {
 		square.setLoadStage(LoadStage.STARTING);
-		square.reset();//Removes all clips & locations so they can be re-applied
 		long start = System.currentTimeMillis();
+		square.preRebuild();//Removes all clips & locations so they can be re-applied
 		
 		int[][][] allZoneData = square.getZoneData();
 		Map<Integer, Archive> baseSquareData = new HashMap<>();
@@ -189,6 +189,7 @@ public final class MapLoader {
 			}
 		}
 
+		square.postRebuild();
 		long loadTime = System.currentTimeMillis() - start;
 		LOGGER.info("Finished loading dynamic map square {}. Source square count: {}, location count: {}, load time: {} ms.", square, baseSquareData.size(), locCount, loadTime);
 		square.setLoadStage(LoadStage.COMPLETED);

--- a/src/main/java/org/virtue/network/protocol/update/ref/Viewport.java
+++ b/src/main/java/org/virtue/network/protocol/update/ref/Viewport.java
@@ -50,17 +50,17 @@ public class Viewport implements GameEventContext {
 	/**
 	 * Represents an array of players within the current player's view
 	 */
-	private Player[] localPlayers;
+	private final Player[] localPlayers;
 	
 	/**
 	 * Represents the npcs currently within the player's viewport
 	 */
-	private List<NPC> localNpcs;
+	private final List<NPC> localNpcs;
 	
 	/**
 	 * Represents an array of players' indices within the current player's view
 	 */
-	private int[] localPlayersIndexes;
+	private final int[] localPlayersIndexes;
 	
 	/**
 	 * Represents the amount of local players within the current player's view
@@ -70,7 +70,7 @@ public class Viewport implements GameEventContext {
 	/**
 	 * Represents an array of players outside the current player's view
 	 */
-	private int[] outPlayersIndexes;
+	private final int[] outPlayersIndexes;
 	
 	/**
 	 * Represents an the amount of players outside the current player's view
@@ -80,17 +80,17 @@ public class Viewport implements GameEventContext {
 	/**
 	 * Represents an array of region hashes
 	 */
-	private int[] regionHashes;
+	private final int[] regionHashes;
 	
 	/**
 	 * Represents an array
 	 */
-	private byte[] slotFlags;
+	private final byte[] slotFlags;
 	
 	/**
 	 * Represents the movement types of all active players
 	 */
-	private byte[] movementTypes;
+	private final byte[] movementTypes;
 	
 	/**
 	 * Represents the amount of players added in the current tick
@@ -100,22 +100,22 @@ public class Viewport implements GameEventContext {
 	/**
 	 * Represents the array of appearance hashes cached in the current runtime
 	 */
-	private byte[][] cachedAppearencesHashes;
+	private final byte[][] cachedAppearencesHashes;
 	
 	/**
 	 * Represents the array of Player head icon hashes cached in the current runtime
 	 */
-	private byte[][] cachedHeadIconsHashes;
+	private final byte[][] cachedHeadIconsHashes;
 	
 	/**
 	 * Represents the array of NPC head icon hashes cached in the current runtime
 	 */
-	private byte[][] cachedNPCHeadIconsHashes;
+	private final byte[][] cachedNPCHeadIconsHashes;
 	
 	/**
 	 * Represents the current player
 	 */
-	private Player player;
+	private final Player player;
 	
 	/**
 	 * Represents if the player has a large scene radius
@@ -130,12 +130,14 @@ public class Viewport implements GameEventContext {
 	/**
 	 * Represents the map regions currently used by the player
 	 */
-	private Set<MapSquare> regions = new HashSet<MapSquare>();
+	private final Set<MapSquare> regions = new HashSet<MapSquare>();
 
 	private boolean dynamicUpdate = false;
 
 	private boolean forceUpdate;
-	
+
+	private CoordGrid lastActiveZone;
+
 	public Viewport(Player player) {
 		this.player = player;
 		sceneRadius = 5;
@@ -405,6 +407,14 @@ public class Viewport implements GameEventContext {
 	
 	public void setSceneRadius(int size) {
 		sceneRadius = size;
+	}
+
+	public CoordGrid getLastActiveZone() {
+		return lastActiveZone;
+	}
+
+	public void setLastActiveZone(CoordGrid lastActiveZone) {
+		this.lastActiveZone = lastActiveZone;
 	}
 
 }


### PR DESCRIPTION
There were some issues with the previous handing of replacement locations - namely, if locations were added while a dynamic map square was rebuilding, they would be cleaned up incorrectly. This change fixes  the issue, as well as:
1. Changing the `map.delayLoc()` function to a generic `map.delay()` function (which acts on the map square itself, and is only cancelled if the entire square gets cleaned up).
2. Preventing the active zone coords from being constantly re-sent with further zone updates if it hasn't changed.

These changes will help the next component of construction - building & removing furniture.