### PR TITLE
Improve skill success algorithms

### DIFF
--- a/src/main/javascript/modules/skill/mining/basic.ts
+++ b/src/main/javascript/modules/skill/mining/basic.ts
@@ -31,7 +31,7 @@ import { addLocation, getLocRotation, getLocShape } from 'shared/map';
 import { giveItem, invHasSpace } from 'shared/inv';
 import { giveXp } from 'shared/stat';
 
-import { runMiningAction } from './common';
+import { runMiningAction, MiningAction } from './logic';
 
 /**
  * @author Im Frizzy <skype:kfriz1998>
@@ -110,137 +110,122 @@ _events.bindEventListener(EventType.OPLOC1, [
 	mineRock(ctx.player, ctx.location, RUNITE_ROCK);
 });
 
+class Rock implements MiningAction {
 
-
-class Rock {
-
-	public readonly level: number;
+	public readonly levelReq: number;
 	public readonly xp: number;
 	public readonly oreId: number;
-	public readonly baseTime: number;
-	public readonly randomTime: number;
 	public readonly respawnDelay: number;
-	public readonly randomLife: number;
+	public readonly baseChance: number;
+	public readonly maxChance: number;
 
-	constructor({ level, xp, oreId, baseTime, randomTime, respawnDelay, randomLife }: Rock) {
-		this.level = level;
+	constructor({ levelReq, xp, oreId, baseChance, maxChance, respawnDelay }: Rock) {
+		this.levelReq = levelReq;
 		this.xp = xp;
 		this.oreId = oreId;
-		this.baseTime = baseTime;
-		this.randomTime = randomTime;
 		this.respawnDelay = respawnDelay;
-		this.randomLife = randomLife;
+		this.baseChance = baseChance;
+		this.maxChance = maxChance;
 	}
 }
 
 const CLAY_ROCK = new Rock({
-	level: 1,
+	levelReq: 1,
 	xp: 5,
 	oreId: 434,
-	baseTime: 10,
-	randomTime: 1,
 	respawnDelay: 5,
-	randomLife: 0
+	baseChance: 80,
+	maxChance: 255
 });
 
 const COPPER_ROCK = new Rock({
-	level: 1,
+	levelReq: 1,
 	xp: 17.5,
 	oreId: 436,
-	baseTime: 10,
-	randomTime: 1,
 	respawnDelay: 5,
-	randomLife: 0
+	baseChance: 80,
+	maxChance: 210
 });
 
 const TIN_ROCK = new Rock({
-	level: 1,
+	levelReq: 1,
 	xp: 17.5,
 	oreId: 438,
-	baseTime: 10,
-	randomTime: 1,
 	respawnDelay: 5,
-	randomLife: 0
+	baseChance: 80,
+	maxChance: 210
 });
 
 const BLURITE_ROCK = new Rock({
-	level: 10,
+	levelReq: 10,
 	xp: 18,
 	oreId: 668,
-	baseTime: 20,
-	randomTime: 1,
 	respawnDelay: 25,
-	randomLife: 0
+	baseChance: 20,
+	maxChance: 1
 });
 
 const IRON_ROCK = new Rock({
-	level: 15,
+	levelReq: 15,
 	xp: 35,
 	oreId: 440,
-	baseTime: 15,
-	randomTime: 1,
 	respawnDelay: 10,
-	randomLife: 0
+	baseChance: 70,
+	maxChance: 200
 });
 
 const SILVER_ROCK = new Rock({
-	level: 20,
+	levelReq: 20,
 	xp: 40,
 	oreId: 442,
-	baseTime: 25,
-	randomTime: 1,
 	respawnDelay: 20,
-	randomLife: 0
+	baseChance: 60,
+	maxChance: 190
 });
 
 const COAL_ROCK = new Rock({
-	level: 30,
+	levelReq: 30,
 	xp: 50,
 	oreId: 453,
-	baseTime: 50,
-	randomTime: 10,
 	respawnDelay: 30,
-	randomLife: 0
+	baseChance: 60,
+	maxChance: 190
 });
 
 const GOLD_ROCK = new Rock({
-	level: 40,
+	levelReq: 40,
 	xp: 60,
 	oreId: 444,
-	baseTime: 80,
-	randomTime: 20,
 	respawnDelay: 40,
-	randomLife: 0
+	baseChance: 40,
+	maxChance: 170
 });
 
 const MITHRIL_ROCK = new Rock({
-	level: 55,
+	levelReq: 55,
 	xp: 80,
 	oreId: 447,
-	baseTime: 100,
-	randomTime: 20,
 	respawnDelay: 60,
-	randomLife: 0
+	baseChance: 20,
+	maxChance: 150
 });
 
 const ADAMANTITE_ROCK = new Rock({
-	level: 70,
+	levelReq: 70,
 	xp: 95,
 	oreId: 449,
-	baseTime: 130,
-	randomTime: 25,
 	respawnDelay: 180,
-	randomLife: 0
+	baseChance: 10,
+	maxChance: 140
 });
 
 const RUNITE_ROCK = new Rock({
-	level: 85,
+	levelReq: 85,
 	xp: 125,
 	oreId: 451,
-	baseTime: 150,
-	randomTime: 30,
 	respawnDelay: 360,
-	randomLife: 0
+	baseChance: 0,
+	maxChance: 130
 });
 
 //TODO: Seren stones need to go in their own script as they have different logic
@@ -262,7 +247,7 @@ function mineRock(player: Player, location: Location, rock: Rock) {
 		sendMessage(player, "Not enough space in your inventory.");
 		return;
 	}
-	runMiningAction(player, rock.level, function() {
+	runMiningAction(player, rock, function() {
 		giveXp(player, Stat.MINING, rock.xp);
 		setEmpty(location, rock.respawnDelay);
 

--- a/src/main/javascript/modules/skill/woodcutting/basic.ts
+++ b/src/main/javascript/modules/skill/woodcutting/basic.ts
@@ -365,6 +365,8 @@ function chopTree(player: Player, location: Location, treeType: Tree, stumpId: n
 		if (treeType === NORMAL_TREE || Math.random() < 0.125) {
 			//If the tree is not a normal tree, there is a 1 in 8 chance of felling it
 			fellTree(location, stumpId, treeType.respawnDelay);
+		} else if (!hasSpace(player)) {
+			sendMessage(player, "Your inventory is too full to hold any more logs.");
 		} else {
 			runWoodcuttingAction(player, treeType, onSuccess);
 		}

--- a/src/main/javascript/modules/skill/woodcutting/basic.ts
+++ b/src/main/javascript/modules/skill/woodcutting/basic.ts
@@ -32,7 +32,7 @@ import { giveItem, hasSpace } from 'shared/inv';
 import { getId } from 'shared/util';
 import { delLocation, getLocRotation, getLocShape } from 'shared/map';
 
-import { runWoodcuttingAction } from './logic';
+import { runWoodcuttingAction, WoodcuttingAction } from './logic';
 
 /**
  * @author Im Frizzy <skype:kfriz1998>
@@ -42,245 +42,263 @@ import { runWoodcuttingAction } from './logic';
  * @author Sundays211
  * @since 05/11/2014
  */
- //Regular trees
- _events.bindEventListener(EventType.OPLOC1, 38760, (ctx) => {
- 		chopTree(ctx.player, ctx.location, NORMAL_TREE, 40350);
- });
+//Regular trees
+_events.bindEventListener(EventType.OPLOC1, 38760, (ctx) => {
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40350);
+});
 
- _events.bindEventListener(EventType.OPLOC1, 38782, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40351);
- });
+_events.bindEventListener(EventType.OPLOC1, 38782, (ctx) => {
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40351);
+});
 
- _events.bindEventListener(EventType.OPLOC1, 38783, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40352);
- });
+_events.bindEventListener(EventType.OPLOC1, 38783, (ctx) => {
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40352);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 38784, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40353);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40353);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 38785, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40354);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40354);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 38786, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40355);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40355);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 38787, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40356);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40356);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 38788, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40357);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40357);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 38789, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40358);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 40358);
+});
 
- //Swamp trees
+//Swamp trees
 _events.bindEventListener(EventType.OPLOC1, 9387, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 10951);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 10951);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 9354, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 11059);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 11059);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 9366, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 11864);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 11864);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 9355, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 11862);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 11862);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 3300, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 11865);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 11865);
+});
 
- //Dead trees
+//Dead trees
 _events.bindEventListener(EventType.OPLOC1, 47594, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 47595);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 47595);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 47596, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 47597);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 47597);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 47598, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 47599);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 47599);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 47600, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 47601);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 47601);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 68901, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 68904);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 68904);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 68902, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 68905);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 68905);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 68903, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 68906);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 68906);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 69144, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 69146);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 69146);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 11866, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 9389);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 9389);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 1282, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 1347);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 1347);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 1383, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 1358);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 1358);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 1286, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 1351);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 1351);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 1289, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 1353);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 1353);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 1291, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 23054);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 23054);
+});
 
- //Dying tree
+//Dying tree
 _events.bindEventListener(EventType.OPLOC1, 24168, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 24169);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 24169);
+});
 
- //Jungle tree
+//Jungle tree
 _events.bindEventListener(EventType.OPLOC1, 4818, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 4819);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 4819);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 4820, (ctx) => {
- 	chopTree(ctx.player, ctx.location, NORMAL_TREE, 4821);
- });
+	chopTree(ctx.player, ctx.location, NORMAL_TREE, 4821);
+});
 
- //Alchey tree
+//Alchey tree
 _events.bindEventListener(EventType.OPLOC1, 69554, (ctx) => {
- 	chopTree(ctx.player, ctx.location, ACHEY_TREE, 69555);
- });
+	chopTree(ctx.player, ctx.location, ACHEY_TREE, 69555);
+});
 
- //Eucalyptus
+//Eucalyptus
 _events.bindEventListener(EventType.OPLOC1, 70068, (ctx) => {
- 	chopTree(ctx.player, ctx.location, EUCALYPTUS_TREE, 70070);
- });
+	chopTree(ctx.player, ctx.location, EUCALYPTUS_TREE, 70070);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 70071, (ctx) => {
- 	chopTree(ctx.player, ctx.location, EUCALYPTUS_TREE, 70073);
- });
+	chopTree(ctx.player, ctx.location, EUCALYPTUS_TREE, 70073);
+});
 
- //Oak
+//Oak
 _events.bindEventListener(EventType.OPLOC1, 38731, (ctx) => {
- 	chopTree(ctx.player, ctx.location, OAK_TREE, 38741);
- });
+	chopTree(ctx.player, ctx.location, OAK_TREE, 38741);
+});
 
 _events.bindEventListener(EventType.OPLOC1, 38732, (ctx) => {
- 	chopTree(ctx.player, ctx.location, OAK_TREE, 38754);
- });
+	chopTree(ctx.player, ctx.location, OAK_TREE, 38754);
+});
 
- //Willow
-_events.bindEventListener(EventType.OPLOC1, [ 38616, 38627, 58006 ] , (ctx) => {
- 	chopTree(ctx.player, ctx.location, WILLOW_TREE, 38725);
- });
+//Willow
+_events.bindEventListener(EventType.OPLOC1, [38616, 38627, 58006], (ctx) => {
+	chopTree(ctx.player, ctx.location, WILLOW_TREE, 38725);
+});
 
- //Maple
-_events.bindEventListener(EventType.OPLOC1, 51843 , (ctx) => {
- 	chopTree(ctx.player, ctx.location, MAPLE_TREE, 54766);
- });
+//Maple
+_events.bindEventListener(EventType.OPLOC1, 51843, (ctx) => {
+	chopTree(ctx.player, ctx.location, MAPLE_TREE, 54766);
+});
 
- //Yew
-_events.bindEventListener(EventType.OPLOC1, 38755 , (ctx) => {
- 	chopTree(ctx.player, ctx.location, YEW_TREE, 38759);
- });
+//Yew
+_events.bindEventListener(EventType.OPLOC1, 38755, (ctx) => {
+	chopTree(ctx.player, ctx.location, YEW_TREE, 38759);
+});
 
- //Magic
-_events.bindEventListener(EventType.OPLOC1, 63176 , (ctx) => {
- 	chopTree(ctx.player, ctx.location, MAGIC_TREE, 63179);
- });
+//Magic
+_events.bindEventListener(EventType.OPLOC1, 63176, (ctx) => {
+	chopTree(ctx.player, ctx.location, MAGIC_TREE, 63179);
+});
 
-_events.bindEventListener(EventType.OPLOC1, 92440 , (ctx) => {
- 	chopTree(ctx.player, ctx.location, MAGIC_TREE, 92441);
- });
+_events.bindEventListener(EventType.OPLOC1, 92440, (ctx) => {
+	chopTree(ctx.player, ctx.location, MAGIC_TREE, 92441);
+});
 
- class Tree {
+class Tree implements WoodcuttingAction {
 
- 	public readonly level: number;
- 	public readonly xp: number;
- 	public readonly logId: number;
- 	public readonly respawnDelay: number;
+	public readonly levelReq: number;
+	public readonly xp: number;
+	public readonly logId: number;
+	public readonly respawnDelay: number;
+	public readonly baseChance: number;
+	public readonly maxChance: number;
 
- 	constructor({ level, xp, logId, respawnDelay }: Tree) {
- 		this.level = level;
- 		this.xp = xp;
- 		this.logId = logId;
- 		this.respawnDelay = respawnDelay;
- 	}
- }
+	constructor({ levelReq, xp, logId, respawnDelay, baseChance, maxChance }: Tree) {
+		this.levelReq = levelReq;
+		this.xp = xp;
+		this.logId = logId;
+		this.respawnDelay = respawnDelay;
+		this.baseChance = baseChance;
+		this.maxChance = maxChance;
+	}
+}
 
 
 const NORMAL_TREE = new Tree({
-	level : 1,
-	xp : 25,
-	logId : 1511,
-	respawnDelay : 8
+	levelReq: 1,
+	xp: 25,
+	logId: 1511,
+	respawnDelay: 8,
+	baseChance: 80,
+	maxChance: 210
 });
 
 const ACHEY_TREE = new Tree({
-	level : 1,
-	xp : 25,
-	logId : 2862,
-	respawnDelay : 8
+	levelReq: 1,
+	xp: 25,
+	logId: 2862,
+	respawnDelay: 8,
+	baseChance: 80,
+	maxChance: 210
 });
 
 const EUCALYPTUS_TREE = new Tree({
-	level : 1,
-	xp : 25,
-	logId : 12581,
-	respawnDelay : 8
+	levelReq: 1,
+	xp: 25,
+	logId: 12581,
+	respawnDelay: 8,
+	baseChance: 80,
+	maxChance: 210
 });
 
 const OAK_TREE = new Tree({
-	level : 15,
-	xp : 35.7,
-	logId : 1521,
-	respawnDelay : 15
+	levelReq: 15,
+	xp: 35.7,
+	logId: 1521,
+	respawnDelay: 15,
+	baseChance: 70,
+	maxChance: 200
 });
 
 const WILLOW_TREE = new Tree({
-	level : 30,
-	xp : 67.5,
-	logId : 1519,
-	respawnDelay : 51
+	levelReq: 30,
+	xp: 67.5,
+	logId: 1519,
+	respawnDelay: 51,
+	baseChance: 60,
+	maxChance: 190
 });
 
 const MAPLE_TREE = new Tree({
-	level : 45,
-	xp : 100,
-	logId : 1517,
-	respawnDelay : 72
+	levelReq: 45,
+	xp: 100,
+	logId: 1517,
+	respawnDelay: 72,
+	baseChance: 40,
+	maxChance: 170
 });
 
 const YEW_TREE = new Tree({
-	level : 60,
-	xp : 175,
-	logId : 1515,
-	respawnDelay : 94
+	levelReq: 60,
+	xp: 175,
+	logId: 1515,
+	respawnDelay: 94,
+	baseChance: 20,
+	maxChance: 150
 });
 
 /*IVY : {//TODO: Ivy needs to go in it's own script as it has custom logic
@@ -290,10 +308,12 @@ const YEW_TREE = new Tree({
     respawnDelay : 58
 },*/
 const MAGIC_TREE = new Tree({
-	level : 75,
-	xp : 250,
-	logId : 1513,
-	respawnDelay : 121
+	levelReq: 75,
+	xp: 250,
+	logId: 1513,
+	respawnDelay: 121,
+	baseChance: 10,
+	maxChance: 140
 });
 
 /*CURSED_MAGIC : {//TODO: These all need to go in their own scripts as they have custom logic
@@ -334,7 +354,7 @@ function chopTree(player: Player, location: Location, treeType: Tree, stumpId: n
 	}
 	var shape = getLocShape(location);
 	var treeCoords = _map.getCoords(location);
-	var onSuccess = function () {
+	var onSuccess = function() {
 		if (_map.getLoc(treeCoords, shape) !== location) {
 			return;//This means the tree has already been felled
 		}
@@ -342,19 +362,19 @@ function chopTree(player: Player, location: Location, treeType: Tree, stumpId: n
 		giveItem(player, treeType.logId, 1);
 		sendSpamMessage(player, "You get some some " + _config.objName(treeType.logId) + ".");
 
-		if (treeType === NORMAL_TREE || Math.random() < 0.2) {
-			//If the tree is not a normal tree, there is a 1 in 5 chance of felling it
+		if (treeType === NORMAL_TREE || Math.random() < 0.125) {
+			//If the tree is not a normal tree, there is a 1 in 8 chance of felling it
 			fellTree(location, stumpId, treeType.respawnDelay);
 		} else {
-			runWoodcuttingAction(player, treeType.level, onSuccess);
+			runWoodcuttingAction(player, treeType, onSuccess);
 		}
 	};
 
 	sendSpamMessage(player, "You swing your hatchet at the tree.");
-	runWoodcuttingAction(player, treeType.level, onSuccess);
+	runWoodcuttingAction(player, treeType, onSuccess);
 }
 
-function fellTree (location: Location, stumpId: number, respawnDelay: number) {
+function fellTree(location: Location, stumpId: number, respawnDelay: number) {
 	var treeCoords = _map.getCoords(location);
 	var treeId = getId(location);
 	var rotation = getLocRotation(location);
@@ -369,7 +389,7 @@ function fellTree (location: Location, stumpId: number, respawnDelay: number) {
 	}
 
 	_map.addLoc(stumpId, treeCoords, shape, rotation);
-	_map.delay(treeCoords, function () {
+	_map.delay(treeCoords, () => {
 		_map.addLoc(treeId, treeCoords, shape, rotation);
 		if (treeTop) {
 			_map.addLoc(getId(treeTop), _map.getCoords(treeTop), shape, getLocRotation(treeTop));

--- a/src/main/javascript/shared/stat.ts
+++ b/src/main/javascript/shared/stat.ts
@@ -1,5 +1,6 @@
 import { Stat } from 'engine/enums/stat';
 import { Player } from 'engine/models';
+import { interpolate } from 'shared/util';
 
 export function boostStat(player: Player, stat: Stat, amount: number) {
 	setStatLevel(player, stat, getStatLevel(player, stat) + amount);
@@ -111,6 +112,16 @@ export function giveBonusXp(player: Player, skill: Stat, amount: number) {
 
 function lookupStat(statName: string): Stat {
 	return ENGINE.getStatByName(statName);
+}
+
+export function randomStatChance (
+	player: Player,
+	stat: Stat,
+	baseChance: number,
+	topChance: number
+) : boolean {
+	const chance = interpolate(baseChance, topChance, 1, 99, getStatLevel(player, stat));
+	return chance > Math.random() * 255;
 }
 
 //TODO: These are legacy exports to support old modules. Remove once the modules have been updated

--- a/src/main/javascript/shared/util.ts
+++ b/src/main/javascript/shared/util.ts
@@ -178,6 +178,10 @@ export function lookupPlayerName(userHash: NodeHash) {
 	return ENGINE.getName(userHash);
 }
 
+export function interpolate (y0: number, y1: number, x0: number, x1: number, x: number): number {
+	return (x - x0) * (y1 - y0) / (x1 - x0) + y0;
+}
+
 /**
  * @deprecated In favour of `_entity.getName()` or `lookupPlayerName()`
  */


### PR DESCRIPTION
This changes the algorithms for mining & woodcutting success chance to use interpolation between a `baseChance` (which fires if the player is level 1 in the skill without any other boosts) and a `maxChance` (if the player is 99 in the skill without any other boosts). Each chance is out of 255.

I'm sure the rates aren't quite right, but it should be easy enough to tweak the two chance variables until it's around what it's supposed to be